### PR TITLE
fix two parse errors

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -216,7 +216,7 @@ mod test {
     fn build_query() {
         let mut bld = Builder::new_query(1573, true);
         let name = Name::from_str("example.com").unwrap();
-        bld = bld.add_question(name, QT::A, QC::IN);
+        bld = bld.add_question(&name, QT::A, QC::IN);
         let result = b"\x06%\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\
                       \x07example\x03com\x00\x00\x01\x00\x01";
         assert_eq!(&bld.build().unwrap()[..], &result[..]);
@@ -226,7 +226,7 @@ mod test {
     fn build_srv_query() {
         let mut bld = Builder::new_query(23513, true);
         let name = Name::from_str("_xmpp-server._tcp.gmail.com").unwrap();
-        bld = bld.add_question(name, QT::SRV, QC::IN);
+        bld = bld.add_question(&name, QT::SRV, QC::IN);
         let result = b"[\xd9\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\
             \x0c_xmpp-server\x04_tcp\x05gmail\x03com\x00\x00!\x00\x01";
         assert_eq!(&bld.build().unwrap()[..], &result[..]);

--- a/src/name.rs
+++ b/src/name.rs
@@ -2,7 +2,6 @@ use std::io;
 use std::fmt;
 use std::fmt::Write;
 use std::str::from_utf8;
-use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::hash;
 
@@ -50,7 +49,7 @@ impl<'a> Name<'a> {
                 return Ok((Name::FromPacket { labels: &data[..pos+2], original: original }, pos + 2));
             } else if byte & 0b1100_0000 == 0 {
                 let end = pos + byte as usize + 1;
-                if !data[pos+1..end].is_ascii() {
+                if from_utf8(&data[pos+1..end]).is_err() {
                     return Err(Error::LabelIsNotAscii);
                 }
                 pos = end;
@@ -164,4 +163,3 @@ impl <'a> PartialEq for Name<'a> {
 }
 
 impl <'a> Eq for Name<'a> {}
-

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -61,7 +61,7 @@ fn parse_record<'a>(data: &'a [u8], offset: &mut usize) -> Result<ResourceRecord
         BigEndian::read_u16(&data[*offset..*offset+2])));
     *offset += 2;
     let cls = try!(Class::parse(
-        BigEndian::read_u16(&data[*offset..*offset+2])));
+        BigEndian::read_u16(&data[*offset..*offset+2]) & 0x7fff ));
     *offset += 2;
     let mut ttl = BigEndian::read_u32(&data[*offset..*offset+4]);
     if ttl > i32::MAX as u32 {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -194,7 +194,7 @@ mod test {
          assert_eq!(packet.answers[0].cls, C::IN);
          assert_eq!(packet.answers[0].ttl, 3600);
          match packet.answers[0].data {
-             RRData::CNAME(cname) => {
+             RRData::CNAME(ref cname) => {
                  assert_eq!(&cname.to_string()[..], "livecms.trafficmanager.net");
              }
              ref x => panic!("Wrong rdata {:?}", x),
@@ -204,7 +204,7 @@ mod test {
          assert_eq!(packet.nameservers[0].cls, C::IN);
          assert_eq!(packet.nameservers[0].ttl, 120275);
          match packet.nameservers[0].data {
-             RRData::NS(ns) => {
+             RRData::NS(ref ns) => {
                  assert_eq!(&ns.to_string()[..], "g.gtld-servers.net");
              }
              ref x => panic!("Wrong rdata {:?}", x),
@@ -339,7 +339,7 @@ mod test {
             assert_eq!(packet.answers[i].cls, C::IN);
             assert_eq!(packet.answers[i].ttl, 900);
             match *&packet.answers[i].data {
-                RRData::SRV { priority, weight, port, target } => {
+                RRData::SRV { priority, weight, port, ref target } => {
                     assert_eq!(priority, items[i].0);
                     assert_eq!(weight, items[i].1);
                     assert_eq!(port, items[i].2);
@@ -394,7 +394,7 @@ mod test {
             assert_eq!(packet.answers[i].cls, C::IN);
             assert_eq!(packet.answers[i].ttl, 1148);
             match *&packet.answers[i].data {
-                RRData::MX { preference, exchange } => {
+                RRData::MX { preference, ref exchange } => {
                     assert_eq!(preference, items[i].0);
                     assert_eq!(exchange.to_string(), (items[i].1).to_string());
                 }
@@ -482,7 +482,7 @@ mod test {
         assert_eq!(packet.answers[0].cls, C::IN);
         assert_eq!(packet.answers[0].ttl, 102);
         match packet.answers[0].data {
-            RRData::CNAME(cname) => {
+            RRData::CNAME(ref cname) => {
                 assert_eq!(&cname.to_string(), "sstatic.net");
             }
             ref x => panic!("Wrong rdata {:?}", x),


### PR DESCRIPTION
This pull contains two fixes:
- names that contain unicode characters, like my old apple tv
- fix one case where the cashe flush bit was not removed before determining the class

Also some fixes on failing tests, unrelated to the other changes
